### PR TITLE
Use `PositionFor` instead of `Position`

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 		startMsg := checkStart(v.fset, stmt.Lbrace, first)
 
 		if wantNewline && startMsg == nil {
-			v.messages = append(v.messages, Message{v.fset.Position(stmt.Pos()), MessageTypeAddAfter, `multi-line statement should be followed by a newline`})
+			v.messages = append(v.messages, Message{v.fset.PositionFor(stmt.Pos(), false), MessageTypeAddAfter, `multi-line statement should be followed by a newline`})
 		} else if !wantNewline && startMsg != nil {
 			v.messages = append(v.messages, *startMsg)
 		}
@@ -106,7 +106,7 @@ func checkMultiLine(v *visitor, body *ast.BlockStmt, stmtStart ast.Node) {
 }
 
 func posLine(fset *token.FileSet, pos token.Pos) int {
-	return fset.Position(pos).Line
+	return fset.PositionFor(pos, false).Line
 }
 
 func firstAndLast(comments []*ast.CommentGroup, fset *token.FileSet, start, end token.Pos, stmts []ast.Stmt) (ast.Node, ast.Node) {
@@ -141,7 +141,7 @@ func checkStart(fset *token.FileSet, start token.Pos, first ast.Node) *Message {
 	}
 
 	if posLine(fset, start)+1 < posLine(fset, first.Pos()) {
-		pos := fset.Position(start)
+		pos := fset.PositionFor(start, false)
 		return &Message{pos, MessageTypeLeading, `unnecessary leading newline`}
 	}
 
@@ -154,7 +154,7 @@ func checkEnd(fset *token.FileSet, end token.Pos, last ast.Node) *Message {
 	}
 
 	if posLine(fset, end)-1 > posLine(fset, last.End()) {
-		pos := fset.Position(end)
+		pos := fset.PositionFor(end, false)
 		return &Message{pos, MessageTypeTrailing, `unnecessary trailing newline`}
 	}
 


### PR DESCRIPTION
If a node has a `//line` comment the position reported from `Position` will be based on that comment. However, when we suggest fixes in `golanngci-lint` we need to do this in the current file, even if it's generated.

This will ensure we get the actual position in the potentially generated file and ignoring the comment directive.

* [Reference for `PositionFor`](https://github.com/golang/go/issues/30761#issuecomment-472151819)
* [Related issue in `golangci-lint`](https://github.com/golangci/golangci-lint/issues/3967)
