### PR TITLE
feat: remove golangci-lint mode

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: oldstable
+          go-version: stable
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,15 +8,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: oldstable
 
       - name: Build
         run: go build -v ./...
 
       - name: Test
         run: go test -v ./...
+
+      - name: Run
+        run: go run ./cmd/whitespace/ ./...

--- a/whitespace_test.go
+++ b/whitespace_test.go
@@ -9,7 +9,6 @@ import (
 func TestWantMultiline(t *testing.T) {
 	testdata := analysistest.TestData()
 	analyzer := NewAnalyzer(&Settings{
-		Mode:      RunningModeNative,
 		MultiIf:   true,
 		MultiFunc: true,
 	})
@@ -20,7 +19,6 @@ func TestWantMultiline(t *testing.T) {
 func TestNoMultiline(t *testing.T) {
 	testdata := analysistest.TestData()
 	analyzer := NewAnalyzer(&Settings{
-		Mode:      RunningModeNative,
 		MultiIf:   false,
 		MultiFunc: false,
 	})


### PR DESCRIPTION
The golangci-lint will not be require anymore, because golangci-lint will be compatible with `SuggestedFix`.

Related to https://github.com/golangci/golangci-lint/pull/5232